### PR TITLE
A few small RPC related fixes

### DIFF
--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -644,9 +644,9 @@ module AMQP
     # marshalled messages that are never consumed.
     #
     #  EM.run do
-    #    server = AMQP::Channel.rpc('hash table node', Hash)
+    #    server = AMQP::Channel.new.rpc('hash table node', Hash)
     #
-    #    client = AMQP::Channel.rpc('hash table node')
+    #    client = AMQP::Channel.new.rpc('hash table node')
     #    client[:now] = Time.now
     #    client[:one] = 1
     #

--- a/lib/amqp/rpc.rb
+++ b/lib/amqp/rpc.rb
@@ -6,9 +6,9 @@ module AMQP
   # Needs more detail and explanation.
   #
   #  EM.run do
-  #    server = AMQP::Channel.rpc('hash table node', Hash)
+  #    server = AMQP::Channel.new.rpc('hash table node', Hash)
   #
-  #    client = AMQP::Channel.rpc('hash table node')
+  #    client = AMQP::Channel.new.rpc('hash table node')
   #    client[:now] = Time.now
   #    client[:one] = 1
   #
@@ -83,8 +83,8 @@ module AMQP
     # works to marshal and unmarshal all method calls and their arguments.
     #
     #  EM.run do
-    #    server = AMQP::Channel.rpc('hash table node', Hash)
-    #    client = AMQP::Channel.rpc('hash table node')
+    #    server = AMQP::Channel.new.rpc('hash table node', Hash)
+    #    client = AMQP::Channel.new.rpc('hash table node')
     #
     #    # calls #method_missing on #[] which marshals the method name and
     #    # arguments to publish them to the remote


### PR DESCRIPTION
Hello,

I've been playing with the RPC class and found out that response messages never reach their way back to the client because in the server code the response queue  should be declared as :auto_delete => true, just like the client code.

I also fixed the RPC examples (there is no more class method #rpc in Channel, need to create a Channel instance first)

Regards,
Yuri
