### PR TITLE
Allow consumers of ruby-amqp to be notified of connection_status changes

### DIFF
--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -27,6 +27,7 @@ module AMQP
 
       timeout @settings[:timeout] if @settings[:timeout]
       errback { @on_disconnect.call } unless @reconnecting
+      @connection_status = @settings[:connection_status]
 
       # TCP connection "openness"
       @tcp_connection_established = false


### PR DESCRIPTION
It seems the only ways to be asynchronously notified of connection completion is to do this or monkeypatch AMQP::Client's initialize to do the equivalent.  Better to facilitate this necessity than to require folks to monkeypatch.
