### PR TITLE
Heartbeat updates

### DIFF
--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -61,7 +61,8 @@ module AMQP
     def init_heartbeat
       @last_server_heartbeat = Time.now
 
-      @timer ||= EM::PeriodicTimer.new(@settings[:heartbeat]) do
+      @timer.cancel if @timer
+      @timer = EM::PeriodicTimer.new(@settings[:heartbeat]) do
         if connected?
           if @last_server_heartbeat < (Time.now - (@settings[:heartbeat] * 2))
             log "Reconnecting due to missing server heartbeats"


### PR DESCRIPTION
According to the AMQP Spec, Heartbeat Frames are Connection-specific, not Channel-specific, thus should occur across Channel 0.  Empirically this doesn't appear to make a difference with recent versions of RabbitMQ, but it's a one-line change to be "more correct", in case it one day does matter.

Also reset the Heartbeat's PeriodicTimer in case the heartbeat interval has been reconfigured/changed in between reconnections.  The commit message contains a relevant use case/scenario.
