### PR TITLE
authentication_spec should include EMSpec, not AMQPSpec

### DIFF
--- a/spec/integration/authentication_spec.rb
+++ b/spec/integration/authentication_spec.rb
@@ -7,7 +7,7 @@ describe "Authentication attempt" do
   # Environment
   #
 
-  include EventedSpec::AMQPSpec
+  include EventedSpec::EMSpec
   include EventedSpec::SpecHelper
 
 


### PR DESCRIPTION
The tests in this file already open connections explicitly.  So the use
of AMQPSpec means that a redundant AMQP connection gets created for each
test.
