### PR TITLE
AMQP URIs should not imply a leading slash in the vhost

### DIFF
--- a/lib/amqp/client.rb
+++ b/lib/amqp/client.rb
@@ -237,7 +237,7 @@ module AMQP
 
       opts[:user]  = URI.unescape(uri.user) if uri.user
       opts[:pass]  = URI.unescape(uri.password) if uri.password
-      opts[:vhost] = URI.unescape(uri.path) if uri.path
+      opts[:vhost] = URI.unescape($1) if uri.path =~ %r{^/([^/]*)}
       opts[:host]  = uri.host if uri.host
       opts[:port]  = uri.port || Hash["amqp" => 5672, "amqps" => 5671][uri.scheme]
       opts[:ssl]   = uri.scheme == "amqps"

--- a/spec/integration/authentication_spec.rb
+++ b/spec/integration/authentication_spec.rb
@@ -92,7 +92,7 @@ describe "Authentication attempt" do
 
       context "and provided credentials are correct" do
         it "succeeds" do
-          connection = AMQP.connect "amqp://#{AMQP_OPTS[:username]}:#{AMQP_OPTS[:password]}@localhost#{AMQP_OPTS[:vhost]}"
+          connection = AMQP.connect "amqp://#{AMQP_OPTS[:username]}:#{AMQP_OPTS[:password]}@localhost/#{URI::escape AMQP_OPTS[:vhost], /[^-_.!~*'()a-zA-Z\d]/n}"
 
           done(0.3) {
             connection.should be_connected
@@ -103,7 +103,7 @@ describe "Authentication attempt" do
 
       context "and provided credentials ARE INCORRECT" do
         it "succeeds" do
-          connection = AMQP.connect "amqp://schadenfreude:#{Time.now.to_i}@localhost/"
+          connection = AMQP.connect "amqp://schadenfreude:#{Time.now.to_i}@localhost"
 
           done(0.5) {
             connection.should_not be_connected


### PR DESCRIPTION
The amqp:// URI convention currently implemented by the amqp gem has a
problem: It uses the path component of the URI as the vhost name,
including the leading slash.

There is no definitive standard for amqp URIs.  But every other
proposed amqp URI scheme (including the two qpid schemes, and the
one implemented by rabbitmq-shovel). uses the path _without_ the
leading slash as the vhost (though they differ in exactly how
they convert the rest of the path to a vhost name).

There is a clear advantage to the more widespread scheme: It can
refer to vhosts that do not begin with a slash (despite the
RabbitMQ default vhost being called '/', there is nothing to
suggest that other vhost names should begin in a slash).  It is
obviously desirable that a URI can be constructured to refer to
any legal vhost.

It's unlikely that the URI connection string is being widely used
so far, so it is a good idea to fix this now.

With this change:

'amqp://host' uses the default vhost '/'

'amqp://host/' uses the vhost with the empty name ''

'amqp://host/foo' uses the vhost named 'foo'

'amqp://host/%2Ffoo' uses the vhost named '/foo'
