### PR TITLE
docs addition to Passenger broker code to preserve functionality of rake 

### DIFF
--- a/docs/ConnectingToTheBroker.textile
+++ b/docs/ConnectingToTheBroker.textile
@@ -454,10 +454,12 @@ Passenger provides a hook that you should use for spawning AMQP connection:
 
 <pre>
 <code>
-PhusionPassenger.on_event(:starting_worker_process) do |forked|
-  if forked
-    # We're in a smart spawning mode
-    # Now is a good place to connect to the broker
+if defined?(PhusionPassenger) # otherwise it breaks rake commands if you put this in an initializer
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    if forked
+      # We're in a smart spawning mode
+      # Now is a good place to connect to the broker
+    end
   end
 end
 </code>


### PR DESCRIPTION
Hey, I had this problem and I'm sure other people will have the same (just try to put the code in an initializer, deploy with capistrano and run cap deploy:migrate).
Hope you like my change!

Alessandro
