### PR TITLE
Fixes a bug where auto_recovery doesn't work with non-durable queues.

### DIFF
--- a/lib/amqp/queue.rb
+++ b/lib/amqp/queue.rb
@@ -811,7 +811,7 @@ module AMQP
 
       shim = Proc.new { |q, declare_ok| block.call(declare_ok.message_count, declare_ok.consumer_count) }
 
-      @channel.once_open { self.declare(true, @durable, @exclusive, @auto_delete, false, nil, &shim) }
+      @channel.once_open { self.declare(@passive, @durable, @exclusive, @auto_delete, false, nil, &shim) }
     end
 
 


### PR DESCRIPTION
Fixes a bug where autorecovery doesn't work with non-durable queues after you query their status.

In AMQP::Queue#status, self.declare is called with the passive parameter set to true. In AMQP::Client::Async::Queue#declare, that value is saved in the passive instance variable which is reused in #redeclare. 

The scenario where this becomes a bug is:
1) You have a non-durable queue in RabbitMQ with a consumer that is auto_recovering.
2) The consumer gets the status of the queue periodically.
3) The Rabbit server goes down; the queue goes away.
4) The consumer attempts to reconnect to Rabbit every X seconds.
5) Rabbit restarts
6) The consumer reconnects and starts the auto_recovery process.
7) The consumer tries to redeclare the above queue, but with passive = true because of the caching of that value in #declare when it was called from AMQP::Queue#status
8) The queue fails to be declared in Rabbit because it doesn't exist (but the consumer's on_recovery callbacks are called for the queue so it appears usable).
