### PR TITLE
Filter sensitive data in exception message

### DIFF
--- a/lib/amqp/exceptions.rb
+++ b/lib/amqp/exceptions.rb
@@ -43,8 +43,17 @@ module AMQP
     def initialize(settings)
       @settings = settings
 
-      super("AMQP broker closed TCP connection before authentication succeeded: this usually means authentication failure due to misconfiguration. Settings are #{settings.inspect}")
+      super("AMQP broker closed TCP connection before authentication succeeded: this usually means authentication failure due to misconfiguration. Settings are #{filtered_settings.inspect}")
     end # initialize(settings)
+
+    def filtered_settings
+      filtered_settings = settings.dup
+      [:pass, :password].each do |sensitve_setting|
+        filtered_settings[sensitve_setting] &&= '[filtered]'
+      end
+
+      filtered_settings
+    end
   end # PossibleAuthenticationFailureError
 
 


### PR DESCRIPTION
In order to avoid leaking credentials in logs, this change replaces
sensitive data in the PossibleAuthenticationFailureError exception
message.
