### PR TITLE
Make sure channel doesn't attempt to send a close message before it's op...

### DIFF
--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -949,10 +949,12 @@ module AMQP
     #
     # @api public
     def close(reply_code = 200, reply_text = DEFAULT_REPLY_TEXT, class_id = 0, method_id = 0, &block)
-      self.status = :closing
-      @connection.send_frame(AMQ::Protocol::Channel::Close.encode(@id, reply_code, reply_text, class_id, method_id))
+      self.once_open do
+        self.status = :closing
+        @connection.send_frame(AMQ::Protocol::Channel::Close.encode(@id, reply_code, reply_text, class_id, method_id))
 
-      self.redefine_callback :close, &block
+        self.redefine_callback :close, &block
+      end
     end
 
     # @endgroup


### PR DESCRIPTION
...ened.

We ran into this issue when using EventMachine as a TCP/IP server and creating an AMQP channel to send messages back to our back-end. If our load balancer hits the TCP/IP side with a heartbeat check, we get a connect/disconnect fast enough that the channel attempts to send the close frame before the open has completed - something like:

Handling a connection-level exception.
            conn.id       : 70236508687680
            conn.open     : false
            AMQP class id : 50,
            AMQP method id: 10,
            Status code   : 504
            Error message : CHANNEL_ERROR - expected 'channel.open'
            state         : #<AMQ::Protocol::Connection::Close:0x007fc26bf74498 @reply_code=504, @reply_text="CHANNEL_ERROR - expected 'channel.open'", @class_id=50, @method_id=10>
