### PR TITLE
Fix auto-recovery

### DIFF
--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -1177,12 +1177,6 @@ module AMQP
       @channel_is_open_deferrable = AMQP::Deferrable.new
     end
 
-    # @return [Boolean] true if this channel uses automatic recovery mode
-    def auto_recovering?
-      @auto_recovery
-    end # auto_recovering?
-
-
     # @return [Hash<String, Consumer>]
     def consumers
       @consumers
@@ -1211,8 +1205,6 @@ module AMQP
     def synchronize(&block)
       @mutex.synchronize(&block)
     end
-
-
 
     # @group QoS and flow handling
 
@@ -1280,21 +1272,6 @@ module AMQP
       @queues.each    { |name, q| q.run_after_recovery_callbacks }
       @exchanges.each { |name, e| e.run_after_recovery_callbacks }
     end
-
-
-    # Called by associated connection object when AMQP connection has been re-established
-    # (for example, after a network failure).
-    #
-    # @api plugin
-    def auto_recover
-      return unless auto_recovering?
-
-      self.open do
-        # exchanges must be recovered first because queue recovery includes recovery of bindings. MK.
-        @exchanges.each { |name, e| e.auto_recover }
-        @queues.each    { |name, q| q.auto_recover }
-      end
-    end # auto_recover
 
     # @endgroup
 


### PR DESCRIPTION
Because the auto_recover method was defined twice, the second method was
getting called rather than he first one. In my testing, this method
recovered my queues, but not my bindings. Deleting it, i.e., reverting
to the first method declared, fixed the issue.
