### PR TITLE
Remove duplicate connect method from session

### DIFF
--- a/lib/amqp/session.rb
+++ b/lib/amqp/session.rb
@@ -148,25 +148,6 @@ module AMQP
         settings[:logging] = boolean
       end
 
-
-      # Establishes connection to AMQ broker and returns it. New connection object is yielded to
-      # the block if it is given.
-      #
-      # @example Specifying adapter via the :adapter option
-      #   AMQP::Adapter.connect(:adapter => "socket")
-      # @example Specifying using custom adapter class
-      #   AMQP::SocketClient.connect
-      # @param [Hash] Connection parameters, including :adapter to use.
-      # @api public
-      def connect(settings = nil, &block)
-        @settings = Settings.configure(settings)
-
-        instance = self.new
-        instance.establish_connection(settings)
-        instance.register_connection_callback(&block)
-
-        instance
-      end
     end
 
 
@@ -531,15 +512,6 @@ module AMQP
           block.call(self)
         end
       end
-    end
-
-
-
-    # For EventMachine adapter, this is a no-op.
-    # @api public
-    def establish_connection(settings)
-      # Unfortunately there doesn't seem to be any sane way
-      # how to get EventMachine connect to the instance level.
     end
 
     alias close disconnect


### PR DESCRIPTION
The Session.connect method is defined twice with minor differences. I
removed the first one to ensure the behavior remains the same, and
because I couldn't quite make sense of it. The first method depended
upon another method, Session#establish_connection, which doesn't
appear to be called anywhere else. I removed that method too.

I don't have specs fully working on my (archlinux) box, but all but 3
specs pass.
