### PR TITLE
Accept string keys in connection parameter hash

### DIFF
--- a/lib/amqp/settings.rb
+++ b/lib/amqp/settings.rb
@@ -73,6 +73,7 @@ module AMQP
     def self.configure(settings = nil)
       case settings
       when Hash then
+        settings = Hash[settings.map {|k, v| [k.to_sym, v] }] # symbolize keys
         if username = settings.delete(:username)
           settings[:user] ||= username
         end


### PR DESCRIPTION
As I was loading the config from a yaml file and so the keys of the hash were all strings, it took me way too long to figure out that all keys needed to be symbols.
