### PR TITLE
Set connection status to closed on connection failure

### DIFF
--- a/lib/amqp/session.rb
+++ b/lib/amqp/session.rb
@@ -174,7 +174,7 @@ module AMQP
       # make it easier to use *args. MK.
       @settings                           = Settings.configure(args.first)
 
-      @on_tcp_connection_failure          = ->(settings) {
+      @on_tcp_connection_failure          = Proc.new { |settings|
         closed!
         if cb = @settings[:on_tcp_connection_failure]
           cb.call(settings)


### PR DESCRIPTION
Without this, reconnect attempts fail because the connection exists but isn't in clos[ed|ing] state.
Now both ways of reconnecting work, via callback and rescuing the error:

``` ruby
def run
  AMQP.start(on_tcp_connection_failure: ->(s) { p :reconnecting; sleep 1; run }) do
    p :connected
  end
end

def run
  begin
    AMQP.start { p :connected }
  rescue
    p :reconnecting; sleep 1; run
  end
end
```
