### PR TITLE
Delete one of the duplicated Queue#auto_recover methods

### DIFF
--- a/examples/error_handling/automatically_recovering_hello_world_consumer.rb
+++ b/examples/error_handling/automatically_recovering_hello_world_consumer.rb
@@ -12,7 +12,7 @@ puts "=> Example of automatic AMQP channel and queues recovery"
 puts
 AMQP.start(:host => ENV.fetch("BROKER_HOST", "localhost")) do |connection, open_ok|
   connection.on_error do |ch, connection_close|
-    raise connection_close.reply_text
+    puts "[connection closed] #{connection_close.reply_text}"
   end
 
   ch1 = AMQP::Channel.new(connection, :auto_recovery => true)

--- a/examples/error_handling/automatically_recovering_hello_world_consumer_that_uses_a_server_named_queue.rb
+++ b/examples/error_handling/automatically_recovering_hello_world_consumer_that_uses_a_server_named_queue.rb
@@ -12,7 +12,7 @@ puts "=> Example of automatic AMQP channel and queues recovery"
 puts
 AMQP.start(:host => "localhost") do |connection, open_ok|
   connection.on_error do |ch, connection_close|
-    raise connection_close.reply_text
+    puts "[connection closed] #{connection_close.reply_text}"
   end
 
   ch1 = AMQP::Channel.new(connection, 2, :auto_recovery => true)


### PR DESCRIPTION
Keep the one that works with server-named queues
