### PR TITLE
Only await ConsumeOk if nowait == false

### DIFF
--- a/lib/amqp/consumer.rb
+++ b/lib/amqp/consumer.rb
@@ -77,9 +77,11 @@ module AMQP
       @channel.once_open do
         @queue.once_declared do
           @connection.send_frame(AMQ::Protocol::Basic::Consume.encode(@channel.id, @queue.name, @consumer_tag, @no_local, @no_ack, @exclusive, nowait, @arguments))
-          self.redefine_callback(:consume, &block)
 
-          @channel.consumers_awaiting_consume_ok.push(self)
+          if !nowait
+            self.redefine_callback(:consume, &block)
+            @channel.consumers_awaiting_consume_ok.push(self)
+          end
 
           self
         end


### PR DESCRIPTION
Bug reproduction steps:
1. Consume a queue with nowait = true (default behaviour).
2. Consume a queue with the :confirm callback option.
3. The confirm callback is never called despite the subscription succeeding.

Example: https://gist.github.com/rianmcguire/ccabb3b539a1e42078ed
