### PR TITLE
Provide concrete example of prefetch usage

### DIFF
--- a/docs/Queues.textile
+++ b/docs/Queues.textile
@@ -783,6 +783,17 @@ all subsequent messages were delivered to `consumer2`:
 The prefetching setting is ignored for consumers that do not use explicit acknowledgements.
 </span>
 
+Queue consumers must explicitly acknowledge message receipt before additional messages are consumed.  To send consumer
+acks, you have to create your consumer with the `ack` argument and call the `ack` method on `AMQP::Header` thusly:
+
+<pre>
+<code>
+queue.subscribe(ack: true) do |amqp_header, payload|
+  # ...
+  amqp_header.ack
+end
+</cpde>
+</pre>
 
 h2. How message acknowledgements relate to transactions and Publisher Confirms
 


### PR DESCRIPTION
I recently suffered through trying to get Queue prefetch working. Neither this gem's nor Rabbit's own docs explained how all of the pieces should go together.  

The existing gem docs mention the `Channel#prefetch` method which sends the basic.qos packet.  However, the docs did not explain the `Queue#subscribe` `ack: new` argument nor the `AMQP::Header#ack` method necessary to connect the dots.

This PR adds a trivial example usage putting all of the pieces together.

Thanks!
