### PR TITLE
Change queues & exchanges method return values back to hash

### DIFF
--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -1184,14 +1184,10 @@ module AMQP
       @consumers
     end # consumers
 
-    # @return  [Array<Queue>]   Collection of queues that were declared on this channel.
-    def queues
-      @queues.values
-    end
 
-    # @return  [Array<Exchange>]  Collection of exchanges that were declared on this channel.
+    # @return  [Hash<Exchange>]  Collection of exchanges that were declared on this channel.
     def exchanges
-      @exchanges.values
+      @exchanges
     end
 
 


### PR DESCRIPTION
queues and exchanges are initialised as hash, and the original definition of queues is returning hash.

returning as arrays would actually cause problems in lib/amqp/queue.rb 's auto_recover method line 1209, since it is expecting a hash.

I have not found any places where array is expected.