### PR TITLE
Depend on amq-protocol ~> 1.9

### DIFF
--- a/amqp.gemspec
+++ b/amqp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.add_dependency "eventmachine"
-  s.add_dependency "amq-protocol", ">= 1.9.2"
+  s.add_dependency "amq-protocol", "~> 1.9"
 
   s.rubyforge_project = "amqp"
 end


### PR DESCRIPTION
amq-protocol 2.0 is breaking for ruby < 2.0

Depending on amq-protocol ~> 1.9 will currently pull 1.9.2 and any new bug-fixes, but will not require amq-protocol 2.0.