### PR TITLE
Depend on amq-protocol ~> 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,6 @@ We cover Web application integration for multiple Ruby Web servers in [Connectin
 
 
 
-## Migration from amqp gem 0.6.x and 0.7.x
-
-Upgrading from amqp gem 0.6.x and 0.7.x to 0.8.0+ is straightforward, please see [amqp gem 0.8.0 migration guide](http://rubyamqp.info/articles/08_migration/).
-The same guide explains amqp gem versions history and why you would want to upgrade.
-
-
-
 ## Maintainer Information
 
 amqp gem is maintained by [Michael Klishin](http://twitter.com/michaelklishin).

--- a/amqp.gemspec
+++ b/amqp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.add_dependency "eventmachine"
-  s.add_dependency "amq-protocol", ">= 1.9.2"
+  s.add_dependency "amq-protocol", "~> 1.9"
 
   s.rubyforge_project = "amqp"
 end

--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -1184,14 +1184,10 @@ module AMQP
       @consumers
     end # consumers
 
-    # @return  [Array<Queue>]   Collection of queues that were declared on this channel.
-    def queues
-      @queues.values
-    end
 
-    # @return  [Array<Exchange>]  Collection of exchanges that were declared on this channel.
+    # @return  [Hash<Exchange>]  Collection of exchanges that were declared on this channel.
     def exchanges
-      @exchanges.values
+      @exchanges
     end
 
 

--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -1414,7 +1414,7 @@ module AMQP
     end
 
 
-    RECOVERY_EVENTS = [:after_connection_interruption, :before_recovery, :after_recovery].freeze
+    RECOVERY_EVENTS = [:after_connection_interruption, :before_recovery, :after_recovery, :error].freeze
 
 
     # @api plugin

--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -342,7 +342,7 @@ module AMQP
       old_id = @id
       # must release after we allocate a new id, otherwise we will end up
       # with the same value. MK.
-      @id    = self.class.next_channel_id
+      @id    = @connection.next_channel_id
       @connection.release_channel_id(old_id)
 
       @channel_is_open_deferrable.fail

--- a/lib/amqp/version.rb
+++ b/lib/amqp/version.rb
@@ -6,5 +6,5 @@ module AMQP
   #
   # @see AMQ::Protocol::VERSION
   # @return [String] AMQP gem version
-  VERSION = '1.5.1.pre'
+  VERSION = '1.6.0.pre'
 end


### PR DESCRIPTION
amq-protocol 2.0 is breaking for ruby < 2.0

Depending on amq-protocol ~> 1.9 will currently pull 1.9.2 and any new bug-fixes, but will not require amq-protocol 2.0.