### PR TITLE
Fix exception "undefined method `method_class'"

### DIFF
--- a/lib/amqp/session.rb
+++ b/lib/amqp/session.rb
@@ -1109,7 +1109,15 @@ module AMQP
     def frameset_complete?(frames)
       return false if frames.empty?
       first_frame = frames[0]
-      first_frame.final? || (first_frame.method_class.has_content? && content_complete?(frames[1..-1]))
+      return true if first_frame.final?
+
+      if first_frame.respond_to?(:method_class)
+        first_frame.method_class.has_content? && content_complete?(frames[1..-1])
+      else
+        logger.error("[amqp] frameset can't start from #{first_frame.class}")
+        frames.delete_at(0)
+        return false
+      end
     end
 
     # Determines, whether given frame array contains full content body


### PR DESCRIPTION
Hello maintainers of this gem.

Last days i struggled with exception "NoMethodError: undefined method `method_class' for #<AMQ::Protocol::BodyFrame:0x0000001e8a60b0>".

I tried solution proposed by @Inanepenguin in #218 , but it didn't work. By "solution" i mean clearing all framesets which are considered completed right after "#receive_frameset".

Finally i came to solution in which the first frame gets dropped from frameset when it's not expected to be first, and code proceeds until entire frameset is read on the channel. I would appreciate if this idea will be implemented in the gem because things begin to work.