### PR TITLE
Avoid some more warnings

### DIFF
--- a/lib/amqp/channel.rb
+++ b/lib/amqp/channel.rb
@@ -1542,7 +1542,7 @@ module AMQP
 
     protected
 
-    @private
+    # @private
     def validate_parameters_match!(entity, parameters, type)
       unless entity.opts.values_at(*@parameter_checks[type]) == parameters.values_at(*@parameter_checks[type]) || parameters[:passive]
         raise AMQP::IncompatibleOptionsError.new(entity.name, entity.opts, parameters)

--- a/lib/amqp/exchange.rb
+++ b/lib/amqp/exchange.rb
@@ -381,12 +381,6 @@ module AMQP
       @on_declare = block
     end
 
-    # @return [Channel]
-    # @api public
-    def channel
-      @channel
-    end
-
     # @return [Boolean] true if this exchange is of type `fanout`
     # @api public
     def fanout?

--- a/lib/amqp/exchange.rb
+++ b/lib/amqp/exchange.rb
@@ -910,7 +910,7 @@ module AMQP
       exchange = channel.find_exchange(method.exchange)
 
       header   = content_frames.shift
-      body     = content_frames.map { |frame| frame.payload }.join
+      body     = content_frames.map { |local_frame| local_frame.payload }.join
 
       exchange.exec_callback(:return, method, header, body)
     end

--- a/lib/amqp/queue.rb
+++ b/lib/amqp/queue.rb
@@ -911,16 +911,6 @@ module AMQP
     end
 
 
-    # @private
-    # @api plugin
-    def handle_connection_interruption(method = nil)
-      @consumers.each { |tag, consumer| consumer.handle_connection_interruption(method) }
-
-      self.exec_callback_yielding_self(:after_connection_interruption)
-
-      @declaration_deferrable = EventMachine::DefaultDeferrable.new
-    end
-
     def handle_declare_ok(method)
       @name = method.queue if @name.empty?
       @channel.register_queue(self)
@@ -1277,6 +1267,8 @@ module AMQP
     end
 
 
+    # @private
+    # @api plugin
     def handle_connection_interruption(method = nil)
       @consumers.each { |tag, c| c.handle_connection_interruption(method) }
     end # handle_connection_interruption(method = nil)

--- a/lib/amqp/queue.rb
+++ b/lib/amqp/queue.rb
@@ -1359,7 +1359,7 @@ module AMQP
       method  = frame.decode_payload
 
       header  = content_frames.shift
-      body    = content_frames.map {|frame| frame.payload }.join
+      body    = content_frames.map {|local_frame| local_frame.payload }.join
 
       queue.handle_get_ok(method, header, body) if queue
     end

--- a/lib/amqp/queue.rb
+++ b/lib/amqp/queue.rb
@@ -148,7 +148,11 @@ module AMQP
     # @return [Array<Hash>] All consumers on this queue.
     attr_reader :consumers
 
-    # @return [AMQP::Consumer] Default consumer (registered with {Queue#consume}).
+    # @return [AMQP::Consumer] Default consumer associated with this queue (if any), or nil
+    # @note Default consumer is the one registered with the convenience {AMQP::Queue#subscribe} method. It has no special properties of any kind.
+    # @see Queue#subscribe
+    # @see AMQP::Consumer
+    # @api public
     attr_reader :default_consumer
 
     # @return [Hash] Additional arguments given on queue declaration. Typically used by AMQP extensions.
@@ -782,15 +786,6 @@ module AMQP
         nil
       end
     end # consumer_tag
-
-    # @return [AMQP::Consumer] Default consumer associated with this queue (if any), or nil
-    # @note Default consumer is the one registered with the convenience {AMQP::Queue#subscribe} method. It has no special properties of any kind.
-    # @see Queue#subscribe
-    # @see AMQP::Consumer
-    # @api public
-    def default_consumer
-      @default_consumer
-    end
 
 
     # @return [Class]


### PR DESCRIPTION
This removes all the warnings we encounter, except the following, which confuses me:

```/home/oz/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/bundler/gems/amqp-00ccb60d5f34/lib/amqp/channel.rb:849: warning: method redefined; discarding old queue
/home/oz/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/bundler/gems/amqp-00ccb60d5f34/lib/amqp/entity.rb:13: warning: previous definition of queue was here
```